### PR TITLE
Add option to disable vertical scrolling

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,7 +30,8 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'androidx.recyclerview:recyclerview:1.1.0-beta05'
-    implementation 'com.github.leshchenko:CircularLayoutManager:1.1.5'
+    //implementation 'com.github.leshchenko:CircularLayoutManager:1.1.5'
+    implementation project(path: ':circularlayoutmanagerlib')
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'

--- a/circularlayoutmanagerlib/src/main/java/com/leshchenko/circularlayoutmanagerlib/CircularRecyclerLayoutManager.kt
+++ b/circularlayoutmanagerlib/src/main/java/com/leshchenko/circularlayoutmanagerlib/CircularRecyclerLayoutManager.kt
@@ -11,6 +11,7 @@ class CircularRecyclerLayoutManager(
     private var firstCircleRadius: Double = Double.NaN,
     private var angleStepForCircles: Double = Double.NaN,
     private val canScrollHorizontally: Boolean = false,
+    private val canScrollVertically: Boolean = true,
     private val initialAngle: Double = 0.0,
     private val isClockwise: Boolean = true
 ) : RecyclerView.LayoutManager() {
@@ -22,7 +23,7 @@ class CircularRecyclerLayoutManager(
 
     override fun canScrollHorizontally() = canScrollHorizontally
 
-    override fun canScrollVertically() = true
+    override fun canScrollVertically() = canScrollVertically
 
     override fun measureChildWithMargins(child: View, widthUsed: Int, heightUsed: Int) {
         child.measure(


### PR DESCRIPTION
For my project/use-case I don't need any scrolling, so I added an option to disable it. I did make it enabled by default to keep current library behaviour.

I also replaced the library import in `app/build.gradle` with a library module import so that changes to the library file will reflect directly in the project app file.

If you want me to change anything please let me know.